### PR TITLE
codegen: Use LLVM C++ API for getDefaultTargetTriple

### DIFF
--- a/src/codegen/CodeGenFunctions.cpp
+++ b/src/codegen/CodeGenFunctions.cpp
@@ -25,7 +25,6 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Utils.h"
-#include "llvm-c/TargetMachine.h"
 
 using namespace llvm;
 
@@ -215,7 +214,7 @@ std::unique_ptr<llvm::Module> ASTProgram::codegen(SemanticAnalysis* analysis,
   auto TheModule = std::make_unique<Module>(programName, TheContext);
 
   // Set the default target triple for this platform
-  TheModule->setTargetTriple(LLVMGetDefaultTargetTriple());
+  TheModule->setTargetTriple(sys::getDefaultTargetTriple());
 
   // Initialize nop declaration
   nop = Intrinsic::getDeclaration(TheModule.get(), Intrinsic::donothing);


### PR DESCRIPTION
We can safely replace the LLVM C API call with C++ API for consistency.