### PR TITLE
Resolves #30

### DIFF
--- a/bin/apt/amazon-corretto-8.sources
+++ b/bin/apt/amazon-corretto-8.sources
@@ -1,0 +1,7 @@
+X-Repolib-Name: Amazon Corretto 8
+Enabled: yes
+Types: deb
+URIs: https://apt.corretto.aws
+Suites: stable
+Components: main
+signed-by: /usr/share/keyrings/amazon-corretto-8-keyring.gpg

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -5,6 +5,7 @@ declare -r ANTLR_VERSION=4
 declare -r JAVA_VERSION=8
 declare -r LLVM_VERSION=11
 
+declare -r ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
 
 echogreen() {
   local green=$(tput setaf 2)
@@ -22,8 +23,12 @@ echoerr() {
 
 
 bootstrap_ubuntu_dependencies() {
-  wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
-  sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+  [ -d /usr/share/keyrings ] || sudo mkdir -p /usr/share/keyrings
+
+  wget https://apt.corretto.aws/corretto.key 
+  gpg --dearmor corretto.key
+  sudo mv corretto.key.gpg /usr/share/keyrings/amazon-corretto-8-keyring.gpg
+  sudo cp ${ROOT_DIR}/bin/apt/amazon-corretto-8.sources /etc/apt/sources.list.d/
   sudo apt -y update
 
   wget https://apt.kitware.com/kitware-archive.sh


### PR DESCRIPTION
stderr from wget was clobbering the sudo prompt when installing
corretto. This PR installs corretto in a way where that doesn't
happen. Further, it stops using the deprecated apt-key utility.