### PR TITLE
use llvm11.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,9 @@ endif()
 ######## LLVM rules for installed libraries ###########
 # We want to select the latest stable release even if others are installed
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  find_package(LLVM 11.0.1 REQUIRED CONFIG)
+  find_package(LLVM 11.1.0 REQUIRED CONFIG)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  find_package(LLVM 11.0.1 REQUIRED CONFIG)
+  find_package(LLVM 11.1.0 REQUIRED CONFIG)
 else()
   message(FATAL_ERROR "${CMAKE_SYSTEM_NAME} is not supported")
 endif()


### PR DESCRIPTION
The llvm version we install in bootstrap is 11.1.0. CMakeLists.txt regressed, and is not out of sync. This pr gets it back inline.