### PR TITLE
upgrade to catch2 v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ Include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG        v2.13.6)
+  GIT_TAG        v3.0.0-preview3)
 
 FetchContent_MakeAvailable(Catch2)
 

--- a/test/unit/codegen/CMakeLists.txt
+++ b/test/unit/codegen/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_executable(codegen_unit_tests)
-target_sources(
-  codegen_unit_tests
-  PRIVATE # First test defines CATCH_CONFIG_MAIN
-          ${CMAKE_CURRENT_SOURCE_DIR}/CodegenFunctionsTest.cpp)
+target_sources(codegen_unit_tests
+               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/CodegenFunctionsTest.cpp)
 target_include_directories(
   codegen_unit_tests
   PRIVATE ${CMAKE_SOURCE_DIR}/src/error
@@ -24,4 +22,4 @@ target_link_libraries(
           codegen
           test_helpers
           coverage_config
-          Catch2::Catch2)
+          Catch2::Catch2WithMain)

--- a/test/unit/codegen/CodegenFunctionsTest.cpp
+++ b/test/unit/codegen/CodegenFunctionsTest.cpp
@@ -1,10 +1,9 @@
-#define CATCH_CONFIG_MAIN
 #include "ParserHelper.h"
 #include "InternalError.h"
 #include "AST.h"
 #include "ASTNodeHelpers.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("CodegenFunction: ASTDeclNode throws InternalError on codegen", "[CodegenFunctions]") {
   ASTDeclNode node("foo");

--- a/test/unit/frontend/ASTBuilderTest.cpp
+++ b/test/unit/frontend/ASTBuilderTest.cpp
@@ -3,7 +3,8 @@
 #include <TIPLexer.h>
 #include <TIPParser.h>
 #include "antlr4-runtime.h"
-#include <catch2/catch.hpp>
+
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/frontend/ASTPrinterTest.cpp
+++ b/test/unit/frontend/ASTPrinterTest.cpp
@@ -1,6 +1,6 @@
 #include "ASTHelper.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/frontend/CMakeLists.txt
+++ b/test/unit/frontend/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_executable(frontend_unit_tests)
 target_sources(
   frontend_unit_tests
-  PRIVATE # First test defines CATCH_CONFIG_MAIN
-          ${CMAKE_CURRENT_SOURCE_DIR}/TIPParserTest.cpp
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/TIPParserTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/PrettyPrinterTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ASTPrinterTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/ASTBuilderTest.cpp
@@ -27,4 +26,4 @@ target_link_libraries(
           codegen
           test_helpers
           coverage_config
-          Catch2::Catch2)
+          Catch2::Catch2WithMain)

--- a/test/unit/frontend/PrettyPrinterTest.cpp
+++ b/test/unit/frontend/PrettyPrinterTest.cpp
@@ -2,7 +2,7 @@
 #include "GeneralHelper.h"
 #include "PrettyPrinter.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/frontend/TIPParserTest.cpp
+++ b/test/unit/frontend/TIPParserTest.cpp
@@ -1,10 +1,9 @@
-#define CATCH_CONFIG_MAIN
 #include "ParserHelper.h"
 #include "FrontEnd.h"
 #include "ParseError.h"
 #include "ExceptionContainsWhat.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("TIP Parser: conditionals", "[TIP Parser]") {
     std::stringstream stream;

--- a/test/unit/frontend/treetypes/ASTProgramTest.cpp
+++ b/test/unit/frontend/treetypes/ASTProgramTest.cpp
@@ -1,6 +1,6 @@
 #include "ASTHelper.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/matchers/ExceptionContainsWhat.h
+++ b/test/unit/matchers/ExceptionContainsWhat.h
@@ -1,12 +1,9 @@
-// NB (nphair): It looks like ANTLR unsets this. Find a better solution.
-#define EOF -1
-
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <iostream>
 #include <string>
 
-class ExceptionContainsWhat : public Catch::MatcherBase<std::exception> {
+class ExceptionContainsWhat : public Catch::Matchers::MatcherBase<std::exception> {
 public:
   ExceptionContainsWhat(std::string const & expected) : expected(expected) {}
 

--- a/test/unit/matchers/ExceptionContainsWhat.h
+++ b/test/unit/matchers/ExceptionContainsWhat.h
@@ -1,4 +1,4 @@
-#include <catch2/catch_all.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 
 #include <iostream>
 #include <string>

--- a/test/unit/semantic/CMakeLists.txt
+++ b/test/unit/semantic/CMakeLists.txt
@@ -4,8 +4,7 @@ add_subdirectory(cfa)
 add_executable(semantic_unit_tests)
 target_sources(
   semantic_unit_tests
-  PRIVATE # First test defines CATCH_CONFIG_MAIN
-          ${CMAKE_CURRENT_SOURCE_DIR}/SymbolTableTest.cpp
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/SymbolTableTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/LocalNameCollectorTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/CheckAssignableTest.cpp)
 target_include_directories(
@@ -33,4 +32,4 @@ target_link_libraries(
           test_helpers
           cfa
           coverage_config
-          Catch2::Catch2)
+          Catch2::Catch2WithMain)

--- a/test/unit/semantic/CheckAssignableTest.cpp
+++ b/test/unit/semantic/CheckAssignableTest.cpp
@@ -3,7 +3,7 @@
 #include "SemanticError.h"
 #include "ExceptionContainsWhat.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/semantic/LocalNameCollectorTest.cpp
+++ b/test/unit/semantic/LocalNameCollectorTest.cpp
@@ -2,7 +2,7 @@
 #include "LocalNameCollector.h"
 #include "ASTNodeHelpers.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 

--- a/test/unit/semantic/SymbolTableTest.cpp
+++ b/test/unit/semantic/SymbolTableTest.cpp
@@ -1,11 +1,9 @@
-#define CATCH_CONFIG_MAIN
-
 #include "ASTHelper.h"
 #include "SymbolTable.h"
 #include "SemanticError.h"
 #include "ExceptionContainsWhat.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 #include <optional>

--- a/test/unit/semantic/cfa/CMakeLists.txt
+++ b/test/unit/semantic/cfa/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(call_graph_unit_tests)
-target_sources(
-  call_graph_unit_tests PRIVATE # First test defines CATCH_CONFIG_MAIN
-                                ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphTest.cpp)
+target_sources(call_graph_unit_tests
+               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/CallGraphTest.cpp)
 target_include_directories(
   call_graph_unit_tests
   PRIVATE ${CMAKE_SOURCE_DIR}/src/error
@@ -30,4 +29,4 @@ target_link_libraries(
           test_helpers
           coverage_config
           cfa
-          Catch2::Catch2)
+          Catch2::Catch2WithMain)

--- a/test/unit/semantic/cfa/CallGraphTest.cpp
+++ b/test/unit/semantic/cfa/CallGraphTest.cpp
@@ -1,10 +1,10 @@
-#define CATCH_CONFIG_MAIN
 #include "CallGraph.h"
 #include "ASTHelper.h"
 #include "SymbolTable.h"
 #include "SemanticAnalysis.h"
-#define EOF -1
-#include <catch2/catch.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
 #include <set>
 
 TEST_CASE("CallGraph: getter for num of vertices and edges" "[CallGraph]") {

--- a/test/unit/semantic/types/CMakeLists.txt
+++ b/test/unit/semantic/types/CMakeLists.txt
@@ -1,8 +1,7 @@
 add_executable(typeinference_unit_tests)
 target_sources(
   typeinference_unit_tests
-  PRIVATE # First test defines CATCH_CONFIG_MAIN
-          ${CMAKE_CURRENT_SOURCE_DIR}/concrete/TipAlphaTest.cpp
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/concrete/TipAlphaTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/concrete/TipConsTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/concrete/TipFunctionTest.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/concrete/TipIntTest.cpp
@@ -39,4 +38,4 @@ target_link_libraries(
           error
           test_helpers
           coverage_config
-          Catch2::Catch2)
+          Catch2::Catch2WithMain)

--- a/test/unit/semantic/types/concrete/TipAlphaTest.cpp
+++ b/test/unit/semantic/types/concrete/TipAlphaTest.cpp
@@ -1,8 +1,7 @@
-#define CATCH_CONFIG_MAIN
 #include "TipAlpha.h"
 #include "ASTNumberExpr.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 

--- a/test/unit/semantic/types/concrete/TipConsTest.cpp
+++ b/test/unit/semantic/types/concrete/TipConsTest.cpp
@@ -5,7 +5,7 @@
 #include "TipVar.h"
 #include "TipTypeVisitor.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 TEST_CASE("TipCons: Test doMatch considers arity" "[TipCons]") {
     auto tipInt = std::make_shared<TipInt>();

--- a/test/unit/semantic/types/concrete/TipFunctionTest.cpp
+++ b/test/unit/semantic/types/concrete/TipFunctionTest.cpp
@@ -2,7 +2,7 @@
 #include "TipRef.h"
 #include "TipFunction.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 #include <iostream>

--- a/test/unit/semantic/types/concrete/TipIntTest.cpp
+++ b/test/unit/semantic/types/concrete/TipIntTest.cpp
@@ -1,7 +1,7 @@
 #include "TipInt.h"
 #include "TipVar.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 #include <string>

--- a/test/unit/semantic/types/concrete/TipMuTest.cpp
+++ b/test/unit/semantic/types/concrete/TipMuTest.cpp
@@ -2,7 +2,8 @@
 #include "TipInt.h"
 #include "TipVar.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #include <memory>
 #include <sstream>
@@ -59,5 +60,5 @@ TEST_CASE("TipMu: test output stream", "[TipMu]") {
     stream << mu;
 
     auto actual = stream.str();
-    REQUIRE_THAT(actual, Catch::Matches("^μ\\[\\[42@\\d+:\\d+\\]\\]\\.int$"));
+    REQUIRE_THAT(actual, Catch::Matchers::Matches("^μ\\[\\[42@\\d+:\\d+\\]\\]\\.int$"));
 }

--- a/test/unit/semantic/types/concrete/TipRecordTest.cpp
+++ b/test/unit/semantic/types/concrete/TipRecordTest.cpp
@@ -2,7 +2,7 @@
 #include "TipRef.h"
 #include "TipRecord.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 #include <iostream>

--- a/test/unit/semantic/types/concrete/TipRefTest.cpp
+++ b/test/unit/semantic/types/concrete/TipRefTest.cpp
@@ -2,7 +2,7 @@
 #include "TipRef.h"
 #include "TipFunction.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <sstream>
 

--- a/test/unit/semantic/types/concrete/TipVarTest.cpp
+++ b/test/unit/semantic/types/concrete/TipVarTest.cpp
@@ -1,7 +1,7 @@
 #include "TipInt.h"
 #include "TipVar.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <vector>
 

--- a/test/unit/semantic/types/constraints/TypeConstraintCollectTest.cpp
+++ b/test/unit/semantic/types/constraints/TypeConstraintCollectTest.cpp
@@ -2,7 +2,7 @@
 #include "ASTHelper.h"
 #include "SymbolTable.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 #include <sstream>

--- a/test/unit/semantic/types/constraints/TypeConstraintTest.cpp
+++ b/test/unit/semantic/types/constraints/TypeConstraintTest.cpp
@@ -2,10 +2,11 @@
 #include "TipFunction.h"
 #include "TipInt.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
-#include <vector>
 #include <sstream>
+#include <vector>
 
 TEST_CASE("TypeConstraint: Constraints are compared term-wise", "[TypeConstraint]") {
     std::vector<std::shared_ptr<TipType>> args;
@@ -27,5 +28,5 @@ TEST_CASE("TypeConstraint: Test output", "[TypeConstraint]") {
 
     std::stringstream sstream;
     sstream << constraint;
-    REQUIRE_THAT(sstream.str(), Catch::Matches("^.* = .*$"));
+    REQUIRE_THAT(sstream.str(), Catch::Matchers::Matches("^.* = .*$"));
 }

--- a/test/unit/semantic/types/solvers/UnifierTest.cpp
+++ b/test/unit/semantic/types/solvers/UnifierTest.cpp
@@ -11,7 +11,7 @@
 #include "UnificationError.h"
 #include "Unifier.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <iostream>
 

--- a/test/unit/semantic/types/solvers/UnionFindTest.cpp
+++ b/test/unit/semantic/types/solvers/UnionFindTest.cpp
@@ -2,7 +2,7 @@
 #include "TipVar.h"
 #include "UnionFind.h"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 #include <memory>
 #include <utility>


### PR DESCRIPTION
Upgrade to catch2 v3.

+ smaller footprint and faster compilation times
+ no more EOF hack
+ V3 is not the main devel branch of catch