### PR TITLE
Fixed a Diff Path in System Tests

### DIFF
--- a/test/system/run.sh
+++ b/test/system/run.sh
@@ -116,7 +116,7 @@ if [[ -s ${SCRATCH_DIR}/fib.diff ]]
 then
   echo -n "Test differences for : " 
   echo $i
-  cat fib.diff
+  cat ${SCRATCH_DIR}/fib.diff
   ((numfailures++))
 fi 
 

--- a/test/system/run.sh
+++ b/test/system/run.sh
@@ -114,8 +114,7 @@ ${TIPC} -pp -ps iotests/fib.tip >${SCRATCH_DIR}/fib.ppps
 diff iotests/fib.ppps ${SCRATCH_DIR}/fib.ppps >${SCRATCH_DIR}/fib.diff
 if [[ -s ${SCRATCH_DIR}/fib.diff ]]
 then
-  echo -n "Test differences for : " 
-  echo $i
+  echo "Test differences for : iotests/fib.tip"
   cat ${SCRATCH_DIR}/fib.diff
   ((numfailures++))
 fi 


### PR DESCRIPTION
When this test failed it printed the error `cat: fib.diff: No such file or directory` instead of the actual differences. I changed the path to include the temporary directory the difference file is stored in.