### PR TITLE
Bootstrap using `~/.zshrc` on Mac if zsh is login shell

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -94,8 +94,23 @@ bootstrap_linux() {
 
 
 bootstrap_mac_env() {
-  echo export LLVM_DIR=$(brew --prefix llvm@$LLVM_VERSION)/lib/cmake >> ~/.bashrc
-  echo export TIPCLANG=$(brew --prefix llvm@$LLVM_VERSION)/bin/clang >> ~/.bashrc
+  # detect login shell
+  case $SHELL in
+    */zsh)
+      # bootstrap for zsh, which is default on macOS >= Catalina
+      echogreen "Bootstrapping env vars for zsh"
+      echo export LLVM_DIR=$(brew --prefix llvm@$LLVM_VERSION)/lib/cmake >> ~/.zshrc
+      echo export TIPCLANG=$(brew --prefix llvm@$LLVM_VERSION)/bin/clang >> ~/.zshrc
+      ;;
+    */bash)
+      # bootstrap for bash, which used to be default
+      echogreen "Bootstrapping env vars for bash"
+      echo export LLVM_DIR=$(brew --prefix llvm@$LLVM_VERSION)/lib/cmake >> ~/.bashrc
+      echo export TIPCLANG=$(brew --prefix llvm@$LLVM_VERSION)/bin/clang >> ~/.bashrc
+      ;;
+    *)
+      echoerr "error: Script has not been implemented for $SHELL"
+  esac
 }
 
 
@@ -137,9 +152,9 @@ bootstrap() {
   esac
 
   echogreen
-  echogreen '--------------------------------------------------------------------------------'
-  echogreen '* bashrc has been updated - be sure to source the file or restart your shell.  *'
-  echogreen '--------------------------------------------------------------------------------'
+  echogreen '--------------------------------------------------------------------------------------'
+  echogreen '* bashrc/zshrc has been updated - be sure to source the file or restart your shell.  *'
+  echogreen '--------------------------------------------------------------------------------------'
 }
 
 bootstrap


### PR DESCRIPTION
`bootstrap.sh` will detect if login shell is bash or zsh and set environment variables in `~/.bashrc` or `~/.zshrc` accordingly.

## Related
This PR fixes #63.

## Testing done
- Ran `bin/bootstrap.sh` with zsh as login shell, confirmed that lines were added to zshrc instead of bashrc
- Changed login shell to bash and ran `bin/bootstrap.sh`, confirmed that lines were added to bashrc

## Discussion
Environment variables for tipc [arguably ought to go in `bash_profile`/`zprofile`](https://apple.stackexchange.com/questions/388622/zsh-zprofile-zshrc-zlogin-what-goes-where), but I used `zshrc` for zsh since we already use `bashrc` for bash.