### PR TITLE
Add setup artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ xml/
 
 # reports
 coverage.out/
+
+# setup artifacts
+corretto.key*
+kitware-archive.sh*
+llvm.sh*

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -27,6 +27,7 @@ bootstrap_ubuntu_dependencies() {
 
   wget https://apt.corretto.aws/corretto.key 
   gpg --dearmor corretto.key
+  rm corretto.key
   sudo mv corretto.key.gpg /usr/share/keyrings/amazon-corretto-${JAVA_VERSION}-keyring.gpg
   sudo cp ${ROOT_DIR}/bin/apt/amazon-corretto-${JAVA_VERSION}.sources /etc/apt/sources.list.d/
   sudo apt -y update
@@ -34,6 +35,7 @@ bootstrap_ubuntu_dependencies() {
   wget https://apt.kitware.com/kitware-archive.sh
   chmod +x kitware-archive.sh
   sudo ./kitware-archive.sh
+  rm kitware-archive.sh
 
   sudo apt -y install \
     java-$JAVA_VERSION-amazon-corretto-jdk \
@@ -53,6 +55,7 @@ bootstrap_ubuntu_dependencies() {
   sed -i -E 's,Ubuntu_(.*),&\n    Pop_\1,g' llvm.sh
   chmod +x llvm.sh
   sudo ./llvm.sh $LLVM_VERSION
+  rm llvm.sh
 
   sudo apt -y install \
     libllvm-$LLVM_VERSION-ocaml-dev \


### PR DESCRIPTION
Running `bin/bootstrap.sh` generates some artifacts used during setup, leaving the working tree unclean. This PR just adds them to `.gitignore` to prevent them being tracked.

I added a `*` pattern after all files since running the script multiple times can create several versions (ex: `llvm.sh.1`).

Alternatively, the bootstrap script could clean up after itself and delete these files - happy to go down that route if that's preferred.