### PR TITLE
Handle additional cases for skipping build link step

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -21,7 +21,7 @@ fi
 
 ${TIPC} $@
 
-# Skip the link step if help is requested 
-if [[ ! "$@" =~ "--help" ]]; then
+# Only perform link step if bitcode has been generated
+if [[ ! "$@" =~ "--help" ]] && [[ ! "$@" =~ "--asm" ]]; then
   ${TIPCLANG} -w ${@: -1}.bc ${RTLIB}/tip_rtlib.bc -o `basename ${@: -1} .tip`
 fi

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -22,6 +22,6 @@ fi
 ${TIPC} $@
 
 # Skip the link step if help is requested 
-if [ $1 != "--help" ]; then
+if [[ ! "$@" =~ "--help" ]]; then
   ${TIPCLANG} -w ${@: -1}.bc ${RTLIB}/tip_rtlib.bc -o `basename ${@: -1} .tip`
 fi


### PR DESCRIPTION
Found some edge cases where `./bin/build.sh` tries to perform the linking step when it shouldn't:
- `--help` is passed, but not in first argument, ex: `./bin/build.sh example.tip --help`
- `--asm` is passed, which does not generate bitcode (resulting in an error when trying to access the generated `.bc` file), ex: `./bin/build.sh example.tip --asm`