### PR TITLE
bump checkout and cache actions and use ubuntu22 for codecov

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
           - macos-13
           - macos-12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: ./bin/bootstrap.sh
       - run: |
           mkdir build
@@ -31,18 +31,18 @@ jobs:
       - name: Cache build
         if: runner.os == 'Linux'
         id: cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: build
           key: linux-build-${{ github.sha }}
   code-coverage:
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Restore build
         id: cache-build
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: build
           key: linux-build-${{ github.sha }}
@@ -55,9 +55,9 @@ jobs:
   docs:
     if: ${{ github.ref == 'refs/heads/main' }}
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt install lcov doxygen graphviz python3 python3-pip python3-setuptools
       - run: python3 -m pip install coverxygen
       - run: ./bin/gendocs.sh


### PR DESCRIPTION
[Looks like][1] it resolves #84 and annoying warning about old node versions.

[1]: https://github.com/nicholasphair/tipc/actions/runs/5746400143/job/15575918328#step:5:1050