### PR TITLE
Fix system tests hanging when AST visualizer test fails

### DIFF
--- a/test/system/run.sh
+++ b/test/system/run.sh
@@ -269,7 +269,7 @@ ${TIPC} --pa=$output_graph $input
 diff $output_graph $expected_output > $diffed_graph
 if [ -s $diffed_graph ]; then
   echo "Test differences for: $input"
-  cat $differences
+  cat $diffed_graph
   ((numfailures++))
 fi
 
@@ -282,7 +282,7 @@ ${TIPC} --pa=$output_graph $input
 diff $output_graph $expected_output > $diffed_graph
 if [ -s $diffed_graph ]; then
   echo "Test differences for: $input" 
-  cat $differences
+  cat $diffed_graph
   ((numfailures++))
 fi 
 


### PR DESCRIPTION
Currently, the system tests hang if the AST visualizer output is different than expected, since the wrong bash variable (`$differences`) is given to `cat`. This causes cat to run with no arguments and wait for input. This PR changes it to the right bash variable, `$diffed_graph`, to make failing tests not cause the tests to hang and output the right debug output.