### PR TITLE
Simplify ASTFunction constructor

### DIFF
--- a/src/frontend/ast/treetypes/ASTFunction.cpp
+++ b/src/frontend/ast/treetypes/ASTFunction.cpp
@@ -2,31 +2,6 @@
 #include "ASTVisitor.h"
 #include "ASTinternal.h"
 
-ASTFunction::ASTFunction(std::shared_ptr<ASTDeclNode> DECL,
-                         std::vector<std::shared_ptr<ASTDeclNode>> FORMALS,
-                         const std::vector<std::shared_ptr<ASTDeclStmt>> &DECLS,
-                         std::vector<std::shared_ptr<ASTStmt>> BODY,
-                         bool ISPOLY) {
-
-  this->DECL = DECL;
-
-  for (auto &formal : FORMALS) {
-    std::shared_ptr<ASTDeclNode> f = formal;
-    this->FORMALS.push_back(f);
-  }
-
-  for (auto &d : DECLS) {
-    this->DECLS.push_back(const_cast<std::shared_ptr<ASTDeclStmt> &>(d));
-  }
-
-  this->ISPOLY = ISPOLY;
-
-  for (auto &stmt : BODY) {
-    std::shared_ptr<ASTStmt> s = stmt;
-    this->BODY.push_back(s);
-  }
-}
-
 std::vector<ASTDeclNode *> ASTFunction::getFormals() const {
   return rawRefs(FORMALS);
 }

--- a/src/frontend/ast/treetypes/ASTFunction.h
+++ b/src/frontend/ast/treetypes/ASTFunction.h
@@ -20,7 +20,9 @@ public:
   ASTFunction(std::shared_ptr<ASTDeclNode> DECL,
               std::vector<std::shared_ptr<ASTDeclNode>> FORMALS,
               const std::vector<std::shared_ptr<ASTDeclStmt>> &DECLS,
-              std::vector<std::shared_ptr<ASTStmt>> BODY, bool ISPOLY);
+              std::vector<std::shared_ptr<ASTStmt>> BODY, bool ISPOLY)
+      : DECL(DECL), FORMALS(FORMALS), DECLS(DECLS), BODY(BODY), ISPOLY(ISPOLY) {
+  }
   ~ASTFunction() = default;
   ASTDeclNode *getDecl() const { return DECL.get(); };
   std::string getName() const { return DECL->getName(); };


### PR DESCRIPTION
I asked about why the `ASTFunction` constructor manually copies everything in the parameter vectors rather than using an initializer list like the other `ASTNode` constructors, and Professor Dwyer said it was a holdover from a previous way the constructor was handled. All tests still pass.

I got confused from the constructor code and don't want anyone in the future to read into it too much like I did.