### PR TITLE
Fix ci-cd build

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -111,7 +111,7 @@ bootstrap_mac_dependencies() {
     exit 1
   fi
 
-  brew install homebrew/cask-versions/corretto$JAVA_VERSION
+  brew install --cask corretto@$JAVA_VERSION
   brew install \
     git \
     cmake \


### PR DESCRIPTION
I noticed the build was breaking on the bootstrapping step. Looks like the java install step changed on mac slightly. Here's a quick fix. 