### PR TITLE
adding Debug build check in CodeGenerator.cpp 

### DIFF
--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -20,3 +20,9 @@ target_include_directories(
 llvm_map_components_to_libnames(llvm_libs Support Core Passes)
 target_link_libraries(codegen PRIVATE ${llvm_libs} semantic error
                                       coverage_config loguru)
+# set C++ definition build flag
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions(-DTIPC_DEBUG)
+else ()
+    add_definitions(-DTIPC_RELEASE)
+endif ()

--- a/src/codegen/CodeGenerator.cpp
+++ b/src/codegen/CodeGenerator.cpp
@@ -21,19 +21,29 @@ void CodeGenerator::emit(llvm::Module *m, std::string filename) {
   std::error_code ec;
   ToolOutputFile result(filename, ec, sys::fs::OF_None);
 
+  // Only enable this routine if the build type is Debug, TIPC_DEBUG definition is declared in src/codegen/CMakeLists.txt
+#ifdef TIPC_DEBUG
   //---
+  // llvm/IR/Verifier gives more precise errors in codegen than lld link-time
+  // errors
+  /// Check a module for errors.
+  ///
+  /// If there are no errors, the function returns false. If an error is
+  /// found, a message describing the error is written to OS (if
+  /// non-null) and true is returned. -- llvm docs.
   std::string errorMessage;
   llvm::raw_string_ostream errorStream(errorMessage);
 
   if (llvm::verifyModule(*m, &errorStream)) {
     // Verification failed, print the error message
-    llvm::errs()<< "ERROR LOG - "  + m->getName().str() + "\n";
+    llvm::errs() << "ERROR LOG FOR - " + m->getName().str() + "\n========\n";
     errorStream.flush();
-    llvm::errs() << "Error: Invalid module - " << errorMessage << "\n";
-
+    llvm::errs() << errorMessage << "\n========\n";
   }
 
   //---
+
+#endif
 
   WriteBitcodeToFile(*m, result.os());
   result.keep();


### PR DESCRIPTION
for llvm::verifyModule(…) call.

This is only helpful in code gen. routine development, and increases workload in Release builds.