### PR TITLE
better multi-shell support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,10 @@ name: build
 
 defaults:
   run:
+    # NOTE: Runners only provide bash (even on macOS).
+    # NOTE: -i to load the bashrc settings.
     shell: bash -ieo pipefail {0}
+
 
 on:
   push:
@@ -15,8 +18,16 @@ jobs:
       matrix:
         os: 
           - ubuntu-22.04
+          - macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - run: |
+          # Let homebrew manage python instead of the 3rd party-install.
+          python_version_number=3.12
+          sudo rm -rf /Library/Frameworks/Python.framework/Versions/${python_version_number}/
+          sudo rm -rf "/Applications/Python ${python_version_number}/"
+          cd /usr/local/bin && ls -l | grep "/Library/Frameworks/Python.framework/Versions/${python_version_number}" | awk '{print $9}' | sudo xargs rm
+        if: runner.os == 'macOS'
       - run: ./bin/bootstrap.sh
       - run: |
           mkdir build
@@ -28,7 +39,7 @@ jobs:
       - name: Cache build
         if: runner.os == 'Linux'
         id: cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build
           key: linux-build-${{ github.sha }}
@@ -36,10 +47,10 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Restore build
         id: cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: build
           key: linux-build-${{ github.sha }}
@@ -54,7 +65,7 @@ jobs:
     needs: build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt install lcov doxygen graphviz python3 python3-pip python3-setuptools
       - run: python3 -m pip install coverxygen
       - run: ./bin/gendocs.sh

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,27 +1,40 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
-declare -r ROOT_DIR=${TIPDIR:-$(git rev-parse --show-toplevel)}
-declare -r TIPC=${ROOT_DIR}/build/src/tipc
-declare -r RTLIB=${ROOT_DIR}/rtlib
 
+# Set ROOT_DIR to TIPDIR or the top-level Git directory if TIPDIR is not set
+ROOT_DIR=${TIPDIR:-$(git rev-parse --show-toplevel)}
+TIPC="${ROOT_DIR}/build/src/tipc"
+RTLIB="${ROOT_DIR}/rtlib"
+
+# Check if TIPCLANG environment variable is set
 if [ -z "${TIPCLANG}" ]; then
-  echo error: TIPCLANG env var must be set
+  echo "error: TIPCLANG env var must be set"
   exit 1
 fi
 
+# Check if the tipc executable exists
 if [ ! -f "${TIPC}" ]; then
-  echo error: tipc was not found
+  echo "error: tipc was not found"
   exit 1
 fi
 
+# Check if the tip_rtlib.bc file exists
 if [ ! -f "${RTLIB}/tip_rtlib.bc" ]; then
-  echo error: tip_rtlib.bc was not found
+  echo "error: tip_rtlib.bc was not found"
   exit 1
 fi
 
-${TIPC} $@
+# Execute tipc with the provided arguments
+${TIPC} "$@"
 
 # Only perform link step if bitcode has been generated
-if [[ ! "$@" =~ "--help" ]] && [[ ! "$@" =~ "--asm" ]]; then
-  ${TIPCLANG} -w ${@: -1}.bc ${RTLIB}/tip_rtlib.bc -o `basename ${@: -1} .tip`
-fi
+case "$*" in
+  *--help*|*--asm*)
+    # Do nothing if --help or --asm is present
+    ;;
+  *)
+    # Perform the linking step
+    ${TIPCLANG} -w "${!#}.bc" "${RTLIB}/tip_rtlib.bc" -o "$(basename "${!#}" .tip)"
+    ;;
+esac
+

--- a/bin/cleancov.sh
+++ b/bin/cleancov.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
-declare -r ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
+#!/bin/sh
+ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
 
-find ${ROOT_DIR} -name '*gcda' -delete
+find "${ROOT_DIR}" -name '*gcda' -delete

--- a/bin/execute.sh
+++ b/bin/execute.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-export TIPCLANG=$(which clang-10)
-
-./build.sh $1
-./`basename ${@:-1} .tip`

--- a/bin/gencov.sh
+++ b/bin/gencov.sh
@@ -1,14 +1,23 @@
-#!/usr/bin/env bash
-declare -r ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
-declare -r COV_OUTPUT=${ROOT_DIR}/coverage.info
-declare -r HTML_OUTPUT=${ROOT_DIR}/coverage.out
+#!/bin/sh
 
-lcov --capture --directory ${ROOT_DIR} --no-external -output-file ${COV_OUTPUT}
-lcov --remove coverage.info ${ROOT_DIR}'/build/*' -o ${COV_OUTPUT}
-lcov --remove coverage.info ${ROOT_DIR}'/externals/*' -o ${COV_OUTPUT}
-lcov --remove coverage.info '*.h' -o coverage.info
-lcov --remove coverage.info '*.hpp' -o coverage.info
-genhtml ${COV_OUTPUT} -output-directory ${HTML_OUTPUT}
+# Set ROOT_DIR to GITHUB_WORKSPACE or the top-level Git directory if GITHUB_WORKSPACE is not set
+ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
+COV_OUTPUT="${ROOT_DIR}/coverage.info"
+HTML_OUTPUT="${ROOT_DIR}/coverage.out"
 
-echo Coverage report has been generated as ${COV_OUTPUT}
-echo An HTML view of this report is available in ${HTML_OUTPUT}
+# Capture coverage data
+lcov --capture --directory "${ROOT_DIR}" --no-external --output-file "${COV_OUTPUT}"
+
+# Remove unwanted coverage data
+lcov --remove "${COV_OUTPUT}" "${ROOT_DIR}/build/*" -o "${COV_OUTPUT}"
+lcov --remove "${COV_OUTPUT}" "${ROOT_DIR}/externals/*" -o "${COV_OUTPUT}"
+lcov --remove "${COV_OUTPUT}" '*.h' -o "${COV_OUTPUT}"
+lcov --remove "${COV_OUTPUT}" '*.hpp' -o "${COV_OUTPUT}"
+
+# Generate HTML report
+genhtml "${COV_OUTPUT}" --output-directory "${HTML_OUTPUT}"
+
+# Print messages to the user
+echo "Coverage report has been generated as ${COV_OUTPUT}"
+echo "An HTML view of this report is available in ${HTML_OUTPUT}"
+

--- a/bin/gendocs.sh
+++ b/bin/gendocs.sh
@@ -1,25 +1,28 @@
-#!/usr/bin/env bash
-declare -r ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
-declare -r DOCS_DIR=${ROOT_DIR}/docs
+#!/bin/sh
 
-pushd $DOCS_DIR
+# Set ROOT_DIR to GITHUB_WORKSPACE or the top-level Git directory if GITHUB_WORKSPACE is not set
+ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
+DOCS_DIR="${ROOT_DIR}/docs"
 
-# Build the docs.
+# Change to the DOCS_DIR directory
+cd "${DOCS_DIR}" || exit 1
+
+# Build the docs using Doxygen
 doxygen
 
-echo 
-echo Documentation has been generated and can be found in ${DOCS_DIR}
-echo You can view the html by opening ${DOCS_DIR}/html/index.html in a browser
-echo 
+echo
+echo "Documentation has been generated and can be found in ${DOCS_DIR}"
+echo "You can view the html by opening ${DOCS_DIR}/html/index.html in a browser"
+echo
 
-python3 -m pip list | grep coverxygen
-if [ $? -ne 0 ]; then
-  echo coverxygen is needed to generate a doc coverage report
-  echo consider installing with pip3 install coverxygen
+# Check if coverxygen is installed
+if ! python3 -m pip list | grep -q coverxygen; then
+  echo "coverxygen is needed to generate a doc coverage report"
+  echo "Consider installing it with pip3 install coverxygen"
   exit 0
 fi
 
-echo Running a coverage report on the generated docs
+echo "Running a coverage report on the generated docs"
 python3 -m coverxygen \
   --xml-dir xml/ \
   --src-dir ../src \
@@ -27,13 +30,13 @@ python3 -m coverxygen \
   --kind class \
   --scope public
 
-# Badges and flags are flaky in codecov. Let's dump some json and 
-# let shields build our badge. 
+# Generate a JSON summary for a badge
 python3 -m coverxygen \
   --xml-dir xml/ \
   --src-dir ../src \
   --output - \
   --format json-summary \
   --kind class \
-  --scope public | 
-  jq '{"schemaVersion": 1,  "label": "doxygen","color":"informational","message": "\((.total.coverage_rate*100 | floor))%"}' > html/doccoverage.json
+  --scope public | \
+  jq '{"schemaVersion": 1, "label": "doxygen", "color":"informational", "message": "\((.total.coverage_rate*100 | floor))%"}' > html/doccoverage.json
+

--- a/bin/runtests.sh
+++ b/bin/runtests.sh
@@ -1,12 +1,14 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
-declare -r ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
-declare -r RTLIB_DIR=${ROOT_DIR}/rtlib
-declare -r UNIT_TEST_DIR=${ROOT_DIR}/build/test/unit
-declare -r SYSTEM_TEST_DIR=${ROOT_DIR}/test/system
 
-usage() { 
-  echo "usage: $0 [-h] [-s] [-u]" 1>&2;
+# Set ROOT_DIR to GITHUB_WORKSPACE or the top-level Git directory if GITHUB_WORKSPACE is not set
+ROOT_DIR=${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel)}
+RTLIB_DIR="${ROOT_DIR}/rtlib"
+UNIT_TEST_DIR="${ROOT_DIR}/build/test/unit"
+SYSTEM_TEST_DIR="${ROOT_DIR}/test/system"
+
+usage() {
+  echo "usage: $0 [-h] [-s] [-u]" 1>&2
   echo "run the complete unit and system test suite"
   echo
   echo "-h  display help"
@@ -15,37 +17,35 @@ usage() {
 }
 
 run_unit_tests() {
-  find ${ROOT_DIR} -name '*gcda' -delete
-  echo running the unit test suite
-  find ${UNIT_TEST_DIR} -name '*_unit_tests' | xargs -n1 sh -c
-  echo unit test run complete
+  find "${ROOT_DIR}" -name '*gcda' -delete
+  echo "running the unit test suite"
+  find "${UNIT_TEST_DIR}" -name '*_unit_tests' | xargs -n1 sh -c
+  echo "unit test run complete"
 }
 
 assert_unit_test_dir() {
-  if [ ! -d ${UNIT_TEST_DIR} ]; then
-    echo ${UNIT_TEST_DIR} was not found. Please make sure you build the project before running tests.
+  if [ ! -d "${UNIT_TEST_DIR}" ]; then
+    echo "${UNIT_TEST_DIR} was not found. Please make sure you build the project before running tests."
     exit 1
   fi
 }
 
 run_system_tests() {
-  pushd ${RTLIB_DIR} &> /dev/null
-  ./build.sh
-  if [ $? -ne 0 ]; then
-    echo error: could not build the runtime library
+  # Change to RTLIB_DIR directory
+  cd "${RTLIB_DIR}" || exit 1
+  if ! ./build.sh; then
+    echo "error: could not build the runtime library"
     exit 1
   fi
-  popd &> /dev/null
 
-  echo running the system test suite
-  pushd ${SYSTEM_TEST_DIR} &> /dev/null
-  ./run.sh
-  if [ $? -ne 0 ]; then
-    echo error while running system tests
+  echo "running the system test suite"
+  # Change to SYSTEM_TEST_DIR directory
+  cd "${SYSTEM_TEST_DIR}" || exit 1
+  if ! ./run.sh; then
+    echo "error while running system tests"
     exit 1
   fi
-  popd &> /dev/null
-  echo system test suite complete
+  echo "system test suite complete"
 }
 
 run_system_tests="true"
@@ -57,21 +57,21 @@ while getopts ":hsu" opt; do
       exit 0
       ;;
     s)
-      echo Preparing to run only the system tests suite
+      echo "Preparing to run only the system tests suite"
       run_unit_tests=""
       ;;
     u)
-      echo Preparing to run only the unit tests suite
+      echo "Preparing to run only the unit tests suite"
       run_system_tests=""
       ;;
     *)
-      echo $0 illegal option
+      echo "$0 illegal option"
       usage
       exit 1
       ;;
   esac
 done
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 if [ -n "${run_unit_tests}" ]; then
   assert_unit_test_dir
@@ -81,3 +81,4 @@ fi
 if [ -n "${run_system_tests}" ]; then
   run_system_tests
 fi
+


### PR DESCRIPTION
Hi Matt,

I saw 2 things that contributed to the broken build.

First, the macOS github runners package a python version that conflicted with the one homebrew used. That was [the error you saw][1]. Since that is something github does as a convenience for build environments (this is not the system python), it seemed appropriate [to just remove it][2].

The other issue was with the shell being used. The short of it is that migrating to zsh required some more updates. The long of it is the scripts in the `bin` directory and the [github runner environment][5] only support bash. So I updated the scripts to be posix compliant (at least [shellcheck][4] tells me they are). That should be enough to support both shells going forward and is why you see more changes than you probably expected. The build seems to be working again though.

[1]: https://github.com/matthewbdwyer/tipc/actions/runs/10453295031/job/28943467545#step:3:143
[2]: https://github.com/matthewbdwyer/tipc/compare/main...nicholasphair:tipc:main?expand=1#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948R25-R29
[3]: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#language-and-runtime
[4]: https://github.com/koalaman/shellcheck
[5]: https://github.com/actions/runner-images/issues/264